### PR TITLE
Use requirements.txt to install Binder Python dependencies

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyyaml

--- a/inspire-try1.ipynb
+++ b/inspire-try1.ipynb
@@ -15,31 +15,13 @@
    "outputs": [],
    "source": [
     "import requests\n",
-    "import json"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#if you are running on Binder, you will need to uncomment the next line and execute it\n",
-    "#!pip install pyyaml "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import json\n",
     "import yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -126,7 +108,7 @@
        " 'doi': '10.1007/JHEP04(2019)046'}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +133,7 @@
        " 'creation_date': '2019-03-27'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +208,7 @@
        "'https://labs.inspirehep.net/api/literature/1726790'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -3762,7 +3744,7 @@
        " 'updated': '2019-04-12T08:14:17.994602+00:00'}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3774,7 +3756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3783,7 +3765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -3792,7 +3774,7 @@
        "dict_keys(['created', 'id', 'links', 'metadata', 'updated'])"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3803,7 +3785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -3812,7 +3794,7 @@
        "'2019-03-27T00:00:00+00:00'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3823,7 +3805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -3832,7 +3814,7 @@
        "dict_keys(['$schema', '_collections', '_desy_bookkeeping', '_export_to', 'abstracts', 'acquisition_source', 'arxiv_eprints', 'authors', 'citeable', 'control_number', 'core', 'curated', 'document_type', 'documents', 'figures', 'inspire_categories', 'keywords', 'legacy_creation_date', 'legacy_version', 'license', 'number_of_pages', 'preprint_date', 'references', 'self', 'texkeys', 'titles'])"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3843,7 +3825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -3852,7 +3834,7 @@
        "True"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3863,7 +3845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Binder recognizes a [variety of configuration files](https://mybinder.readthedocs.io/en/latest/config_files.html) to prepare the runtime of the Binder for the user during the build so that no additional actions need to be taken. To avoid having a Binder user having to do any work to install libraries with Jupyter magics in the notebook this PR uses the Binder [`requirements.txt`](https://mybinder.readthedocs.io/en/latest/config_files.html#requirements-txt-install-a-python-environment) config file to install any Python libraries not included in the stdlib. This also harmonizes the notebook between running locally and in Binder, which is preferable.

For an example, see the Binder running on this branch on my fork: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/inspire_play/feature/add-binder-requirements.txt)

I realize that this repo was started to do work and try things out, so the number of libraries in the `requirements.txt` might need to expand in the future, but I thought it might be helpful to start using it now rather than when this exploitative project is done.